### PR TITLE
Fix instance search when inside a <template> tag

### DIFF
--- a/parser/src/vue/communication-channels.test.ts
+++ b/parser/src/vue/communication-channels.test.ts
@@ -1,13 +1,41 @@
 import { JSDOM } from 'jsdom';
 
-import { isPropUsed, isEventUsed, isSlotUsed, getUsedChannels } from './communication-channels';
+import {
+    findDependencyInstancesInTemplate,
+    isPropUsed,
+    isEventUsed,
+    isSlotUsed,
+    getUsedChannels
+} from './communication-channels';
 
 const createComponent = (template: string) => {
-    const { document } = new JSDOM(template).window;
-    return document.querySelector('ComponentName');
+    const fragment = JSDOM.fragment(template);
+    return fragment.querySelector('ComponentName');
 };
 
 describe('parser', () => {
+    describe('findDependencyInstancesInTemplate', () => {
+        it('should find a component usage in camel case', function () {
+            const template = '<div><TestComponent>test</TestComponent></div>';
+            expect(findDependencyInstancesInTemplate(template, 'TestComponent')).toHaveLength(1);
+        });
+
+        it('should find a component usage in kebab case', function () {
+            const template = '<div><test-component>test</test-component></div>';
+            expect(findDependencyInstancesInTemplate(template, 'TestComponent')).toHaveLength(1);
+        });
+
+        it('should find multiple usages of a component', function () {
+            const template = '<div><test-component>test</test-component><TestComponent>test</TestComponent></div>';
+            expect(findDependencyInstancesInTemplate(template, 'TestComponent')).toHaveLength(2);
+        });
+
+        it('should find a component usage inside of a template tag', function () {
+            const template = '<template><template v-if="true"><test-component>test</test-component></template></template>';
+            expect(findDependencyInstancesInTemplate(template, 'TestComponent')).toHaveLength(1);
+        });
+    });
+    
     describe('isPropUsed', () => {
         it('should find the prop in kebab syntax', () => {
             const prop = { name: 'TestProp', type: { name: 'String' }, default: 'Test', required: false };

--- a/parser/src/vue/communication-channels.ts
+++ b/parser/src/vue/communication-channels.ts
@@ -6,9 +6,10 @@ import { Dependency, Event, Prop, Slot, VueComponent } from '../../types';
 import { kebabize } from '../utils/kababize';
 
 export const findDependencyInstancesInTemplate = (template: string, name: string): Element[] => {
-  const { document } = new JSDOM(template).window;
-  const dependencyUsagesCamelCase = Array.from(document.querySelectorAll(name));
-  const dependencyUsagesKebabCase = Array.from(document.querySelectorAll(kebabize(name)));
+  const templateWithoutTemplateTags = template.replace(/template/g, 'temp-tag');
+  const fragment = JSDOM.fragment(templateWithoutTemplateTags);
+  const dependencyUsagesCamelCase = Array.from(fragment.querySelectorAll(name));
+  const dependencyUsagesKebabCase = Array.from(fragment.querySelectorAll(kebabize(name)));
   return [...dependencyUsagesCamelCase, ...dependencyUsagesKebabCase];
 };
 


### PR DESCRIPTION
QuerySelector in JSDOM does not find anything when the component
is defined inside a <template> tag. In order to work around that
all <template> tags are replaced with <temp-tag> before the search.